### PR TITLE
Update Textfield.js

### DIFF
--- a/lib/mdl/Textfield.js
+++ b/lib/mdl/Textfield.js
@@ -325,9 +325,12 @@ class Textfield extends Component {
   }
 
   _doMeasurement() {
-    this.refs.input.measure(this._onInputMeasured.bind(this));
-    if (this.props.floatingLabelEnabled) {
-      this.refs.floatingLabel.measure(this._onLabelMeasured.bind(this));
+    if (this.refs.input) {
+      //the component may have been unmounted when the requestAnimationFrome running it
+      this.refs.input.measure(this._onInputMeasured.bind(this));
+      if (this.props.floatingLabelEnabled) {
+        this.refs.floatingLabel.measure(this._onLabelMeasured.bind(this));
+      }
     }
   }
 


### PR DESCRIPTION
When the _doMeasurement is running, it is possible the component has been unmounted which causing this.refs.input is not available.